### PR TITLE
Plot CV NOT based on relative change from SQ

### DIFF
--- a/app.R
+++ b/app.R
@@ -428,7 +428,8 @@ server <- function(input, output, session){
           dplyr::group_by(draw) %>%
           dplyr::mutate(SQ_value = (value[model == "SQproposed"]),
                  pct_diff = 100 * (value - SQ_value) / SQ_value) %>%
-          dplyr::ungroup()
+          dplyr::ungroup() %>%
+          dplyr::mutate(CV = value)
 
         catch<- outputs() %>%
           #dat %>%
@@ -442,7 +443,7 @@ server <- function(input, output, session){
           tidyr::pivot_wider(names_from = species, values_from = Value) %>%
           dplyr::left_join(welfare) %>%
           dplyr::group_by(model) %>%
-          dplyr::summarise(`Angler Satisfaction($)` = median(CV),
+          dplyr::summarise(`Angler Satisfaction($)` = median(CV)/1000000,
                            cod = median(cod),
                            hadd = median(hadd))
 
@@ -451,7 +452,7 @@ server <- function(input, output, session){
           ggplot2::geom_hline( yintercept =cod_acl())+
           ggplot2::geom_text(ggplot2::aes(label=model), check_overlap = TRUE)+
           ggplot2::geom_text(ggplot2::aes(y=cod_acl(), label="Cod ACL", x=0)) +
-          ggplot2::xlab("Relative Change in Angler Satisfaction ($)")+
+          ggplot2::xlab("Change in Angler Satisfaction ($M)")+
           ggplot2::ylab("Total Recreational Cod Mortality (mt)")+
           ggplot2::labs(title = "Cod Mortality (mt) compared to Angler Satisfaction (Compared to the past year, how much better- or worse-off are anglers, in dollars?)",
                         subtitle = "testing")+
@@ -482,7 +483,8 @@ server <- function(input, output, session){
           dplyr::group_by(draw) %>%
           dplyr::mutate(SQ_value = (value[model == "SQproposed"]),
                  pct_diff = 100 * (value - SQ_value) / SQ_value) %>%
-          dplyr::ungroup()
+          dplyr::ungroup() %>%
+          dplyr::mutate(CV = value)
 
         catch<- outputs() %>%
           #dat %>%
@@ -496,7 +498,7 @@ server <- function(input, output, session){
           tidyr::pivot_wider(names_from = species, values_from = Value) %>%
           dplyr::left_join(welfare) %>%
           dplyr::group_by(model) %>%
-          dplyr::summarise(`Angler Satisfaction($)` = median(CV),
+          dplyr::summarise(`Angler Satisfaction($)` = median(CV)/1000000,
                            cod = median(cod),
                            hadd = median(hadd))
 
@@ -504,7 +506,7 @@ server <- function(input, output, session){
           ggplot2::geom_point() +
           ggplot2::geom_hline( yintercept =had_acl())+
           ggplot2::geom_text(ggplot2::aes(label=model), check_overlap = TRUE)+
-          ggplot2::xlab("Relative Change in Angler Satisfaction ($)")+
+          ggplot2::xlab("Change in Angler Satisfaction ($M)")+
           ggplot2::ylab("Total Recreational Haddock Mortality (mt)")+
           ggplot2::geom_text(ggplot2::aes(x=0, label="Had ACL", y=had_acl())) +
           ggplot2::labs(title = "Haddock Mortality (mt) compared to Angler Satisfaction (Compared to the past year, how much better- or worse-off are anglers, in dollars?)",


### PR DESCRIPTION
In a past we showed in the tool: ((CV_newreg-CV_SQ)/CV_SQ)*100 = percent difference in CV compared to status quo. I don't like this, even though I'm the one who thought of it in the first place. We should keep these values as dollars. 

In my edits to app.R, I simply changed the plot object from pct_diff to CV (raw model output). These values are interpreted as the dollar value of changes in angler satisfaction compared to angler satisfaction in the past year. I then changed the label of the plot accordingly.

I have not tested this so Kim please check that it works. 
