### PR TITLE
No change directories

### DIFF
--- a/Code/pre_sim/MRIP_column_cases.do
+++ b/Code/pre_sim/MRIP_column_cases.do
@@ -1,50 +1,49 @@
 
-cd $misc_data_cd
 
 
 * This code only needs to be run once after new MRIP data enters the repo
 * It handles  casing for the datasets
 *
-foreach wave in	$yr_wvs {				
+qui foreach wave in	$yr_wvs {				
 
-capture confirm file "trip_`wave'.dta"
+capture confirm file "${misc_data_cd}/trip_`wave'.dta"
 if _rc==0{
-	use trip_`wave'.dta, clear
+	use "${misc_data_cd}/trip_`wave'.dta", clear
 	renvarlab, lower
-	save trip_`wave'.dta, replace
+	save "${misc_data_cd}/trip_`wave'.dta", replace
 }
 
 else{
 	
 }
 
-capture confirm file "size_b2_`wave'.dta"
+capture confirm file ""${misc_data_cd}/size_b2_`wave'.dta"
 if _rc==0{
-	use size_b2_`wave'.dta, clear
+	use "${misc_data_cd}/size_b2_`wave'.dta", clear
 	renvarlab, lower
-	save size_b2_`wave'.dta, replace
+	save ""${misc_data_cd}/size_b2_`wave'.dta", replace
 }
 
 else{
 	
 }
 
-capture confirm file "size_`wave'.dta"
+capture confirm file "${misc_data_cd}/size_`wave'.dta"
 if _rc==0{
-	use size_`wave'.dta, clear
+	use "${misc_data_cd}/size_`wave'.dta", clear
 	renvarlab, lower
-	save size_`wave'.dta, replace
+	save "${misc_data_cd}/size_`wave'.dta", replace
 }
 
 else{
 	
 }
 
-capture confirm file "catch_`wave'.dta"
+capture confirm file "${misc_data_cd}/catch_`wave'.dta"
 if _rc==0{
-	use catch_`wave'.dta, clear
+	use "${misc_data_cd}/catch_`wave'.dta", clear
 	renvarlab, lower
-	save catch_`wave'.dta, replace
+	save "${misc_data_cd}/catch_`wave'.dta", replace
 }
 
 else{
@@ -52,26 +51,5 @@ else{
 }
 
 }
-*
 
-/*catchlist -- this assembles then names of files that are needed in the catchlist */
-/*Check to see if the file exists */	/* If the file exists, add the filename to the list if there are observations */
-global catchlist
-foreach year in $yearlist{
-	foreach wave in $wavelist{
-	capture confirm file "catch_`year'`wave'.dta"
-	if _rc==0{
-		use "catch_`year'`wave'.dta", clear
-		quietly count
-		scalar tt=r(N)
-		if scalar(tt)>0{
-			global catchlist "$catchlist "catch_`year'`wave'.dta " " 
-		}
-		else{
-		}
-	}
-	else{
-	}
-	
-}
-}
+

--- a/Code/pre_sim/MRIP_lists.do
+++ b/Code/pre_sim/MRIP_lists.do
@@ -1,18 +1,15 @@
-
-cd $misc_data_cd
-
 /*catchlist -- this assembles names of files that are needed in the catchlist */
 /*Check to see if the file exists */	/* If the file exists, add the filename to the list if there are observations */
 global catchlist
 foreach year in $yearlist{
 	foreach wave in $wavelist{
-	capture confirm file "catch_`year'`wave'.dta"
+	capture confirm file "$misc_data_cd/catch_`year'`wave'.dta"
 	if _rc==0{
-		use "catch_`year'`wave'.dta", clear
+		use "$misc_data_cd/catch_`year'`wave'.dta", clear
 		quietly count
 		scalar tt=r(N)
 		if scalar(tt)>0{
-			global catchlist "$catchlist "catch_`year'`wave'.dta " " 
+			global catchlist "$catchlist "$misc_data_cd/catch_`year'`wave'.dta" " 
 		}
 		else{
 		}
@@ -28,13 +25,13 @@ foreach year in $yearlist{
 global triplist
 foreach year in $yearlist{
 	foreach wave in  $wavelist{
-	capture confirm file "trip_`year'`wave'.dta"
+	capture confirm file "$misc_data_cd/trip_`year'`wave'.dta"
 	if _rc==0{
-		use "trip_`year'`wave'.dta", clear
+		use "$misc_data_cd/trip_`year'`wave'.dta", clear
 		quietly count
 		scalar tt=r(N)
 		if scalar(tt)>0{
-			global triplist "$triplist "trip_`year'`wave'.dta " " 
+			global triplist "$triplist "$misc_data_cd/trip_`year'`wave'.dta" " 
 		}
 		else{
 		}
@@ -49,13 +46,13 @@ foreach year in $yearlist{
 global b2list
 foreach year in $yearlist{
 	foreach wave in $wavelist{
-	capture confirm file "size_b2_`year'`wave'.dta"
+	capture confirm file "$misc_data_cd/size_b2_`year'`wave'.dta"
 	if _rc==0{
-		use "size_b2_`year'`wave'.dta", clear
+		use "$misc_data_cd/size_b2_`year'`wave'.dta", clear
 		quietly count
 		scalar tt=r(N)
 		if scalar(tt)>0{
-			global b2list "$b2list "size_b2_`year'`wave'.dta " " 
+			global b2list "$b2list "$misc_data_cd/size_b2_`year'`wave'.dta " " 
 		}
 		else{
 		}
@@ -71,13 +68,13 @@ foreach year in $yearlist{
 global sizelist
 foreach year in $yearlist{
 	foreach wave in $wavelist{
-	capture confirm file "size_`year'`wave'.dta"
+	capture confirm file "$misc_data_cd/size_`year'`wave'.dta"
 	if _rc==0{
-	use "size_`year'`wave'.dta", clear
+	use "$misc_data_cd/size_`year'`wave'.dta", clear
 	quietly count
 	scalar tt=r(N)
 	if scalar(tt)>0{
-		global sizelist "$sizelist "size_`year'`wave'.dta " " 
+		global sizelist "$sizelist "$misc_data_cd/size_`year'`wave'.dta" " 
 		}
 		else{
 		}
@@ -87,6 +84,3 @@ foreach year in $yearlist{
 	
 }
 }
-
-/* better to not use the cd at the top, but this is a little patch */
-cd $here

--- a/Code/pre_sim/calibration_catch_per_trip_part1.do
+++ b/Code/pre_sim/calibration_catch_per_trip_part1.do
@@ -20,7 +20,6 @@ set seed $seed
 
 * Pull in MRIP data
 
-cd $misc_data_cd
 
 clear
 mata: mata clear
@@ -460,7 +459,6 @@ save "$misc_data_cd\baseline_mrip_catch_processed.dta", replace
 * Compute MRIP estimates for comparison with simulated estimates 
 
 * Estimates by mode
-cd $misc_data_cd
 
 clear
 mata: mata clear
@@ -685,7 +683,6 @@ save "$misc_data_cd\mrip_catch_by_mode.dta", replace
 
 
 * Estimates by mode and month 
-cd $misc_data_cd
 
 clear
 mata: mata clear
@@ -906,7 +903,6 @@ save "$misc_data_cd\mrip_catch_by_mode_month.dta", replace
 
 
 * Estimates by mode and season 
-cd $misc_data_cd
 
 clear
 mata: mata clear

--- a/Code/pre_sim/catch_at_length_calibration.do
+++ b/Code/pre_sim/catch_at_length_calibration.do
@@ -8,8 +8,6 @@ set seed $seed
 * MRIP discard lengths  
 **************************
 
-cd $misc_data_cd
-
 clear
 
 mata: mata clear

--- a/Code/pre_sim/directed_trips_calibration.do
+++ b/Code/pre_sim/directed_trips_calibration.do
@@ -10,7 +10,6 @@
 		
 set seed $seed 
 
-cd $misc_data_cd
 
 clear
 global fluke_effort
@@ -474,7 +473,6 @@ export delimited using "$misc_data_cd\next_year_calendar_adjustments.csv",  repl
 ****Part C****
 *Compute totals estimates to compare with simulated calibration output
 * estimates by mode
-cd $input_data_cd
 
 clear
 global fluke_effort
@@ -643,7 +641,6 @@ save "$misc_data_cd\mrip_dtrip_by_mode.dta", replace
 
 
 * estimates by mode and month 
-cd $misc_data_cd
 
 clear
 global fluke_effort
@@ -812,7 +809,6 @@ save "$misc_data_cd\mrip_dtrip_by_mode_month.dta", replace
 
 
 * estimates by mode and summer/winter season
-cd $misc_data_cd
 
 clear
 global fluke_effort

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -160,7 +160,6 @@ if `proto' {
 /* This code requires you to mount your google drive to D on your computer */
 if `pull_assessment' {
 	di "Pulling Assessment data from google"
-	cd $here
 
 	do "$input_code_cd\get_assessment_from_gdrive.do"
 }
@@ -172,7 +171,6 @@ if `pull_assessment' {
 
 if `processMRIP' {
 	di "Processing MRIP data"
-	cd $here
 
 	do "$input_code_cd\MRIP_column_cases.do"
 	di "MRIP data processed"
@@ -180,7 +178,6 @@ if `processMRIP' {
 
 if `assemblemriplists' {
 	di "Assembling Lists of MRIP files"
-	cd $here
 
 	do "$input_code_cd\MRIP_lists.do"
 	di "Lists of MRIP files assembled"

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -191,7 +191,6 @@ if `estimate_dtrips' {
 	di "Estimating Directed trips"
 	*This file calls "set_regulations.do". In it you must enter the SQ regulations in the calibration and projection year. 
 	*THIS NEEDS TO BE ADJUSTED EVERY YEAR. 
-	cd $here
 
 	do "$input_code_cd\directed_trips_calibration.do"
 	di "Directed trips Estimated"
@@ -202,7 +201,6 @@ if `estimate_dtrips' {
 // 3) Create distributions of costs per trip across strata - only needs to be run once
 if `costs_per_trip' {
 	di "Creating distributions of cost per trip"
-	cd $here
 
 	do "$input_code_cd\survey_trip_costs.do"
 	di "distributions of cost per trip Done"
@@ -211,7 +209,6 @@ if `costs_per_trip' {
 // 4) Create draw of angler preference parameters - only needs to be run once
 if `draw_angler_preferences' {
 	di "Creating draws of angler preference parameters"
-	cd $here
 	do "$input_code_cd\estimate_angler_preferences.do" 
 	di "Draws of angler preference parameters Done"
 
@@ -220,7 +217,6 @@ if `draw_angler_preferences' {
 		//a) compute mean catch-per-trip and standard error, imputing standard errors from historcial data when they are missing. 
 if `catch_per_trip1' {
 	di "Estimate catch-per-trip at the month and mode level"
-	cd $here
 
 	do "$input_code_cd\calibration_catch_per_trip_part1.do"
 	di "catch-per-trip at the month and mode level Done"
@@ -230,7 +226,6 @@ if `catch_per_trip1' {
 if `copula_in_R' {
 	 /* this takes a while and will look like it's hung. it's not */
     	di "Estimating copula in R. This takes a while and will look like it's hung"
-	cd $here
 
 		rscript using "$input_code_cd\copula_modeling_calibration.R"
     	di "Copula in R estimated"
@@ -239,7 +234,6 @@ if `copula_in_R' {
 		//c) generate estimates of simulated total harvest based on random draws of catch-per-trip and directed trips
 if `catch_per_trip2' {
     	di "Generating estimates of simulated total harvest based on random draws"
-	cd $here
 
 		do "$input_code_cd\calibration_catch_per_trip_part2.do"
     	di "Estimates of simulated total harvest Done"
@@ -257,7 +251,6 @@ if `compare_calibration_MRIP' {
 // 7) Process catch-per-trip and format it for the rec dashboard
 if `prep_cpt_for_dashboard'{
     	di "Processing and formatting catch-per-trip for dashboard"
-	cd $here
 
 		do "$input_code_cd\rdb_processing_catch_per_trip.do"
     	di "Processing and formatting catch-per-trip for dashboard done"
@@ -266,7 +259,6 @@ if `prep_cpt_for_dashboard'{
 		//run this script in R to read in the catch per trip processed for the rec dashboard, save it as an Rds, and push it to Google Drive
 if `Rpush_to_gdrive'{
     	di "Pushing rec dashboard data to gdrive using R" 
-	cd $here
 
 		rscript using "$input_code_cd\rdb_catch_per_trip_to_drive.R"
 	    di "Rec dashboard data pushed to gdrive " 
@@ -275,7 +267,6 @@ if `Rpush_to_gdrive'{
 // 8) add additonal angler demographics based on results of utilty model
 if `angler_demogs'{
     	di "Adding additional angler demographics" 
-	cd $here
 
 		do "$input_code_cd\additional_angler_dems.do" 
     	di "Additional angler demographics done" 
@@ -284,7 +275,6 @@ if `angler_demogs'{
 // 9) Generate baseline-year catch-at-length, using the simulated harvest/discard totals from step 5
 if `generate_baseline'{
     	di "Generating baseline catch-at-length" 
-	cd $here
 
 		do "$input_code_cd\catch_at_length_calibration.do"
     	di "Baseline catch-at-length generated " 
@@ -293,7 +283,6 @@ if `generate_baseline'{
 // 10) Generate projection-year catch-at-length, incorporating the stock assessment data
 if `catch_at_length_project'{
 		di "Generating projection year catch-at-length" 
-	cd $here
 
 		do "$input_code_cd\catch_at_length_projection.do"
     	di "Projection year catch-at-length generated " 

--- a/Code/pre_sim/rdb_processing_catch_per_trip.do
+++ b/Code/pre_sim/rdb_processing_catch_per_trip.do
@@ -19,9 +19,8 @@ This code cleans the simulated catch per trip data compiled in compare_calibrati
   
 */
 
-cd $misc_data_cd
 
-u simulated_catch_totals3.dta, clear
+u "$misc_data_cd\simulated_catch_totals3.dta", clear
 
 *keep only necessary columns
 keep mode month dtrip cod_cat_sim hadd_cat_sim


### PR DESCRIPTION
Remove all "cd" lines from the pre_sim workflow.

The major change happens where we assemble the lists of files.  We read the full path and file name into the global instead of the just the file name. This means we don't have to switch to that directory when we read it in later. 

Tested working on a slightly short version of the wrapper.