### PR TITLE
Use mriptacklebox to pull MRIP data from oracle.

### DIFF
--- a/Code/helpers/developer_setup.R
+++ b/Code/helpers/developer_setup.R
@@ -9,7 +9,7 @@ stopifnot(developer %in% c("TP", "LCH", "ML", "KB"))
 if (developer=="LCH"){
   gf.data.dir<-"E:/Lou_projects/groundfishRDM/2027_mgt_cycle"
 } else if (developer %in% c("TP","ML", "KB")){
-  dir.create(here("Data","2027_mgt_cycle"), showWarnings = TRUE, recursive=TRUE)
+  dir.create(here("Data","2027_mgt_cycle"), showWarnings = FALSE, recursive=TRUE)
   gf.data.dir<-here("Data","2027_mgt_cycle")
 }
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -1,4 +1,19 @@
 # this R helper file pulls MRIP data from Oracle using the mriptacklebox.
+# it takes 2 arguments, first_year and last_year, in sequence.
+
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2) {
+  stop("Error: This script requires exactly two arguments.", call. = FALSE)
+}
+
+first_yr  <- as.numeric(args[1])
+last_yr   <-  as.numeric(args[2])# Convert to numeric if needed
+
+
+cat("First Year:", first_yr, "\n")
+cat("Last Year:", last_yr, "\n")
+
 
 
 # install the mt2 (dev) branch
@@ -17,8 +32,6 @@ here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
 
 output_folder<-file.path(gf.data.dir, "miscellaneous")
-first_yr<-2023
-last_yr<-2026
 
 drv<-dbDriver("Oracle")
 con_name<-eval(nefscdb_con)
@@ -40,27 +53,27 @@ x <- map(x, ~ rename_with(.x, tolower))
 
 # append the date ran to the object
 
-x$date_ran<-Sys.Date()
+x$DateRan<-Sys.Date()
 # write this to an rds file.
 write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
 
 # write this to an dtas file.
 write_dta(x$trip,
           path=file.path(output_folder,
-                         glue("mrip_trip_{first_yr}_{last_yr}.dta"))
+                         glue("mrip_trip.dta"))
 )
 
 write_dta(x$catch,
           path=file.path(output_folder,
-              glue("mrip_catch_{first_yr}_{last_yr}.dta"))
+              glue("mrip_catch.dta"))
           )
 
 write_dta(x$size,
           path=file.path(output_folder,
-                         glue("mrip_size_{first_yr}_{last_yr}.dta"))
+                         glue("mrip_size.dta"))
 )
 write_dta(x$size_b2,
           path=file.path(output_folder,
-                         glue("mrip_size_b2_{first_yr}_{last_yr}.dta"))
+                         glue("mrip_size_b2.dta"))
 )
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -17,12 +17,14 @@ here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
 
 output_folder<-file.path(gf.data.dir, "miscellaneous")
-
+first_yr<-2023
+last_yr<-2026
 
 drv<-dbDriver("Oracle")
 con_name<-eval(nefscdb_con)
 
-yearlist<-2023:2026
+
+yearlist<-first_yr:last_yr
 wavelist<-1:6
 
 x <- mrip_microdata(
@@ -36,5 +38,26 @@ x <- mrip_microdata(
 # all lower case
 x <- map(x, ~ rename_with(.x, tolower))
 
-write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
 # write this to an rds file.
+write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
+
+# write this to an dtas file.
+write_dta(x$trip,
+          path=file.path(output_folder,
+                         glue("mrip_trip{first_yr}_{last_yr}.dta"))
+)
+
+write_dta(x$catch,
+          path=file.path(output_folder,
+              glue("mrip_catch{first_yr}_{last_yr}.dta"))
+          )
+
+write_dta(x$size,
+          path=file.path(output_folder,
+                         glue("mrip_size{first_yr}_{last_yr}.dta"))
+)
+write_dta(x$size_b2,
+          path=file.path(output_folder,
+                         glue("mrip_size_b2{first_yr}_{last_yr}.dta"))
+)
+

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -22,8 +22,8 @@ cat("Last Year:", last_yr, "\n")
 
 # Load libraries
 # install the main branch
-#remotes::install_github("NEFSC/READ-PDB-mriptacklebox",
-#                        , upgrade="never")
+#remotes::install_github("NEFSC/READ-PDB-mriptacklebox")
+
 library("here")
 library("mriptacklebox")
 library("ROracle")
@@ -34,7 +34,7 @@ library("haven")
 library("conflicted")
 
 
-# standard "here"
+# standard "here", username setup, and paths
 here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -32,6 +32,8 @@ library("DBI")
 library("glue")
 library("haven")
 library("conflicted")
+conflicts_prefer(dplyr::filter)
+conflicts_prefer(dplyr::lag)
 
 
 # standard "here", username setup, and paths
@@ -91,7 +93,7 @@ colnames(datestamp)<-"mrip_pull_date"
 mrip_pull$mrip_pull_date<-datestamp
 
 # write this to an rds file.
-write_rds(mrip_pull, file=file.path(output_folder, glue("mrip_pull.Rds")))
+write_rds(mrip_pull, file=file.path(output_folder, glue("mrip_pull{todaysdate}.Rds")))
 
-message("MRIP data pulled on: ", format(todaysdate,"%B %d, %Y") )
+message("MRIP data successfully pulled on: ", format(todaysdate,"%B %d, %Y") )
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -37,8 +37,10 @@ library("conflicted")
 # standard "here", username setup, and paths
 here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
-
 output_folder<-file.path(gf.data.dir, "miscellaneous")
+
+#for help with versioning
+todaysdate<-Sys.Date()
 
 # Connect to Oracle
 drv<-dbDriver("Oracle")
@@ -64,9 +66,9 @@ dbDisconnect(con_name)
 mrip_pull <- map(mrip_pull, ~rename_with(.x, tolower)
                  )
 
-#append DateRan into all elements
+#append mrip_pull_date into all elements. Force it to July 16, 2026 format
 mrip_pull <- map(mrip_pull, ~ mutate(
-  .x, DateRan = as.character(Sys.Date()))
+  .x, mrip_pull_date =as.character(format(todaysdate,"%B %d, %Y") ) )
   )
 
 #force certain things to character
@@ -82,8 +84,14 @@ walk2(mrip_pull, names(mrip_pull), ~ write_dta(
   )
 )
 
-# append the DateRan to the mrip_pull object
+# append the mrip_pull_date to the mrip_pull list as a tibble
 
-mrip_pull$DateRan<-Sys.Date()
+datestamp<-as_tibble(todaysdate)
+colnames(datestamp)<-"mrip_pull_date"
+mrip_pull$mrip_pull_date<-datestamp
+
 # write this to an rds file.
 write_rds(mrip_pull, file=file.path(output_folder, glue("mrip_pull.Rds")))
+
+message("MRIP data pulled on: ", format(todaysdate,"%B %d, %Y") )
+

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -82,7 +82,7 @@ mrip_pull <- map(mrip_pull, ~ mutate(
 # write all the elements of x to a dta file
 walk2(mrip_pull, names(mrip_pull), ~ write_dta(
   .x,
-  path=file.path(output_folder, glue("{.y}.dta"))
+  path=file.path(output_folder, glue("mrip_{.y}.dta"))
   )
 )
 

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -51,6 +51,18 @@ x <- mrip_microdata(
 # all lower case
 x <- map(x, ~ rename_with(.x, tolower))
 
+# destring
+destring_col <- function(col) {
+  if (!is.character(col)) return(col)
+  converted <- suppressWarnings(as.numeric(col))
+  new_nas <- is.na(converted) & !is.na(col)
+  if (any(new_nas)) col else converted
+}
+
+x <- map(x, ~ mutate(.x, across(where(is.character), destring_col)))
+
+
+
 # append the date ran to the object
 
 x$DateRan<-Sys.Date()

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -21,8 +21,8 @@ cat("Last Year:", last_yr, "\n")
 
 
 # Load libraries
-# install the mt2 (dev) branch
-#remotes::install_github("NEFSC/READ-PDB-mriptacklebox@mt2",
+# install the main branch
+#remotes::install_github("NEFSC/READ-PDB-mriptacklebox",
 #                        , upgrade="never")
 library("here")
 library("mriptacklebox")

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -1,21 +1,26 @@
 # this R helper file pulls MRIP data from Oracle using the mriptacklebox.
 # it takes 2 arguments, first_year and last_year, in sequence.
+# because it takes 2 arguments, you'll have to run it from the command line with
+# Rscript get_mrip_oracle.R 2023 2025
+# or you can run it from stata
 
 
+# Define arguments
 args <- commandArgs(trailingOnly = TRUE)
 if (length(args) != 2) {
   stop("Error: This script requires exactly two arguments.", call. = FALSE)
 }
 
+#read in arguments. Ensure they are numeric
 first_yr  <- as.numeric(args[1])
-last_yr   <-  as.numeric(args[2])# Convert to numeric if needed
+last_yr   <-  as.numeric(args[2])
 
-
+# Show them, just in case.
 cat("First Year:", first_yr, "\n")
 cat("Last Year:", last_yr, "\n")
 
 
-
+# Load libraries
 # install the mt2 (dev) branch
 #remotes::install_github("NEFSC/READ-PDB-mriptacklebox@mt2",
 #                        , upgrade="never")
@@ -28,11 +33,14 @@ library("glue")
 library("haven")
 library("conflicted")
 
+
+# standard "here"
 here::i_am("Code/pre_sim/get_mrip_oracle.R")
 source(here("Code", "helpers", "developer_setup.R"))
 
 output_folder<-file.path(gf.data.dir, "miscellaneous")
 
+# Connect to Oracle
 drv<-dbDriver("Oracle")
 con_name<-eval(nefscdb_con)
 
@@ -40,52 +48,42 @@ con_name<-eval(nefscdb_con)
 yearlist<-first_yr:last_yr
 wavelist<-1:6
 
-x <- mrip_microdata(
+# pull data and then disconnect
+mrip_pull <- mrip_microdata(
   years = yearlist, waves = wavelist,
   typ = c('trip', 'catch', 'size', 'size_b2'),
   format = c('nefsc_db'),
   nefsc_db_con=con_name
 )
+dbDisconnect(con_name)
 
+
+# A little data munging
 
 # all lower case
-x <- map(x, ~ rename_with(.x, tolower))
+mrip_pull <- map(mrip_pull, ~rename_with(.x, tolower)
+                 )
 
-# destring
-destring_col <- function(col) {
-  if (!is.character(col)) return(col)
-  converted <- suppressWarnings(as.numeric(col))
-  new_nas <- is.na(converted) & !is.na(col)
-  if (any(new_nas)) col else converted
-}
+#append DateRan into all elements
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, DateRan = as.character(Sys.Date()))
+  )
 
-x <- map(x, ~ mutate(.x, across(where(is.character), destring_col)))
+#force certain things to character
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, across(c(strat_id, psu_id, id_code,zip), as.character))
+  )
 
 
+# write all the elements of x to a dta file
+walk2(mrip_pull, names(mrip_pull), ~ write_dta(
+  .x,
+  path=file.path(output_folder, glue("{.y}.dta"))
+  )
+)
 
-# append the date ran to the object
+# append the DateRan to the mrip_pull object
 
-x$DateRan<-Sys.Date()
+mrip_pull$DateRan<-Sys.Date()
 # write this to an rds file.
-write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
-
-# write this to an dtas file.
-write_dta(x$trip,
-          path=file.path(output_folder,
-                         glue("mrip_trip.dta"))
-)
-
-write_dta(x$catch,
-          path=file.path(output_folder,
-              glue("mrip_catch.dta"))
-          )
-
-write_dta(x$size,
-          path=file.path(output_folder,
-                         glue("mrip_size.dta"))
-)
-write_dta(x$size_b2,
-          path=file.path(output_folder,
-                         glue("mrip_size_b2.dta"))
-)
-
+write_rds(mrip_pull, file=file.path(output_folder, glue("mrip_pull.Rds")))

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -1,0 +1,33 @@
+# this R helper file pulls MRIP data from Oracle using the mriptacklebox.
+
+
+# install the database_testing branch
+remotes::install_github("NEFSC/READ-PDB-mriptacklebox@database_testing",
+                        , upgrade="never")
+
+library("mriptacklebox")
+library("ROracle")
+library("tidyverse")
+library("conflicted")
+library("DBI")
+
+drv<-dbDriver("Oracle")
+con_name<-eval(nefscdb_con)
+
+yearlist<-2024:2025
+wavelist<-1:6
+
+x <- mrip_microdata(
+  years = yearlist, waves = wavelist,
+  typ = c('trip', 'catch', 'size', 'size_b2'),
+  format = c('nefsc_db'),
+  nefsc_db_con=con_name
+)
+
+
+
+# all lower case
+x <- map(x, ~ rename_with(.x, tolower))
+
+
+# write this to an rds file.

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -1,20 +1,28 @@
 # this R helper file pulls MRIP data from Oracle using the mriptacklebox.
 
 
-# install the database_testing branch
-remotes::install_github("NEFSC/READ-PDB-mriptacklebox@database_testing",
-                        , upgrade="never")
-
+# install the mt2 (dev) branch
+#remotes::install_github("NEFSC/READ-PDB-mriptacklebox@mt2",
+#                        , upgrade="never")
+library("here")
 library("mriptacklebox")
 library("ROracle")
 library("tidyverse")
-library("conflicted")
 library("DBI")
+library("glue")
+library("haven")
+library("conflicted")
+
+here::i_am("Code/pre_sim/get_mrip_oracle.R")
+source(here("Code", "helpers", "developer_setup.R"))
+
+output_folder<-file.path(gf.data.dir, "miscellaneous")
+
 
 drv<-dbDriver("Oracle")
 con_name<-eval(nefscdb_con)
 
-yearlist<-2024:2025
+yearlist<-2023:2026
 wavelist<-1:6
 
 x <- mrip_microdata(
@@ -25,9 +33,8 @@ x <- mrip_microdata(
 )
 
 
-
 # all lower case
 x <- map(x, ~ rename_with(.x, tolower))
 
-
+write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
 # write this to an rds file.

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -38,26 +38,29 @@ x <- mrip_microdata(
 # all lower case
 x <- map(x, ~ rename_with(.x, tolower))
 
+# append the date ran to the object
+
+x$date_ran<-Sys.Date()
 # write this to an rds file.
 write_rds(x, file=file.path(output_folder, glue("mrip_pull.Rds")))
 
 # write this to an dtas file.
 write_dta(x$trip,
           path=file.path(output_folder,
-                         glue("mrip_trip{first_yr}_{last_yr}.dta"))
+                         glue("mrip_trip_{first_yr}_{last_yr}.dta"))
 )
 
 write_dta(x$catch,
           path=file.path(output_folder,
-              glue("mrip_catch{first_yr}_{last_yr}.dta"))
+              glue("mrip_catch_{first_yr}_{last_yr}.dta"))
           )
 
 write_dta(x$size,
           path=file.path(output_folder,
-                         glue("mrip_size{first_yr}_{last_yr}.dta"))
+                         glue("mrip_size_{first_yr}_{last_yr}.dta"))
 )
 write_dta(x$size_b2,
           path=file.path(output_folder,
-                         glue("mrip_size_b2{first_yr}_{last_yr}.dta"))
+                         glue("mrip_size_b2_{first_yr}_{last_yr}.dta"))
 )
 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -132,24 +132,24 @@ global trawl_survey_start_year 2022
 **********************************************************************
 
 // Control which modules to run (set to 0 to skip)
-loc pull_assessment = 1		 		// Pull Assessment data
-loc processMRIP = 1		 			// deal with casing MRIP data
-loc assemblemriplists = 1		 	// deal with casing MRIP data
+loc pull_assessment = 0		 		// Pull Assessment data
+loc pull_MRIP = 0		 			// Pull MRIP data
 
+loc processMRIP = 0		 			// deal with casing MRIP data
+loc assemblemriplists =0		 	// deal with casing MRIP data
 loc estimate_dtrips = 1				// Estimate Directed Trips 
-loc pull_MRIP = 1		 		// Pull MRIP data
-loc costs_per_trip = 1  			// Create Distributions of costs per trip (run 1x)
-loc draw_angler_preferences = 1		// Create draw of angler preference parameters (run 1x)
+loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
+loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
 loc catch_per_trip1 = 1				// Part 1 of catch per trip
-loc copula_in_R = 1					// Copula model in R
-loc catch_per_trip2 = 1				// Part 2 of catch per trip
+loc copula_in_R = 2					// Copula model in R
+loc catch_per_trip2 = 2				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
 loc prep_cpt_for_dashboard= 1		// prep data for dashboard
-loc Rpush_to_gdrive =1 				// Push to google drive in R
-loc angler_demogs	=1				// add additonal angler demographics
+loc Rpush_to_gdrive =0 				// Push to google drive in R
+loc angler_demogs	=0				// add additonal angler demographics
 loc generate_baseline=1				// Generate baseline-year catch-at-length
 loc catch_at_length_project=1			// Generate projection-year catch-at-length
-loc run_calibration=1						// Run calibration routine in R
+loc run_calibration=0						// Run calibration routine in R
 
 
 
@@ -173,11 +173,23 @@ if `pull_assessment' {
 
 // 0) Pull MRIP data from Oracle (takes a while).
 
+
+
+
+global catchlist "$misc_data_cd/mrip_catch.dta"
+global triplist  "$misc_data_cd/mrip_trip.dta"
+global b2list  "$misc_data_cd/mrip_size.dta"
+global sizelist  "$misc_data_cd/mrip_size_b2.dta"
+
+
+
 if `pull_MRIP' {
 	di "Pulling MRIP data from oracle"
 		rscript using "$input_code_cd\get_mrip_oracle.R", args($first_mrip_year $last_mrip_year)
-
+	do "$input_code_cd"\tidyup_mrip_data_fromR.do"
+	
 }
+
 
 
 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -132,24 +132,24 @@ global trawl_survey_start_year 2022
 **********************************************************************
 
 // Control which modules to run (set to 0 to skip)
-loc pull_assessment = 0		 		// Pull Assessment data
-loc pull_MRIP = 0		 			// Pull MRIP data
+loc pull_assessment = 1		 		// Pull Assessment data
+loc pull_MRIP = 1		 			// Pull MRIP data
 
 loc processMRIP = 0		 			// deal with casing MRIP data
 loc assemblemriplists =0		 	// deal with casing MRIP data
-loc estimate_dtrips = 1				// Estimate Directed Trips 
-loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
-loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
+loc estimate_dtrips = 1				// Estimate Directed Trips
+loc costs_per_trip = 1  			// Create Distributions of costs per trip (run 1x)
+loc draw_angler_preferences = 1		// Create draw of angler preference parameters (run 1x)
 loc catch_per_trip1 = 1				// Part 1 of catch per trip
-loc copula_in_R = 2					// Copula model in R
-loc catch_per_trip2 = 2				// Part 2 of catch per trip
+loc copula_in_R = 1					// Copula model in R
+loc catch_per_trip2 = 1				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
 loc prep_cpt_for_dashboard= 1		// prep data for dashboard
-loc Rpush_to_gdrive =0 				// Push to google drive in R
-loc angler_demogs	=0				// add additonal angler demographics
+loc Rpush_to_gdrive =1 				// Push to google drive in R
+loc angler_demogs	=1				// add additonal angler demographics
 loc generate_baseline=1				// Generate baseline-year catch-at-length
 loc catch_at_length_project=1			// Generate projection-year catch-at-length
-loc run_calibration=0						// Run calibration routine in R
+loc run_calibration=1						// Run calibration routine in R
 
 
 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -186,7 +186,8 @@ global sizelist  "$misc_data_cd/mrip_size_b2.dta"
 if `pull_MRIP' {
 	di "Pulling MRIP data from oracle"
 		rscript using "$input_code_cd\get_mrip_oracle.R", args($first_mrip_year $last_mrip_year)
-	do "$input_code_cd"\tidyup_mrip_data_fromR.do"
+	
+	do "$input_code_cd\tidyup_mrip_data_fromR.do"
 	
 }
 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -106,8 +106,10 @@ global seed 03211990
 global yr_wvs 20231 20232 20233 20234 20235 20236  ///
 			  20241 20242 20243 20244 20245 20246  ///
 			  20251 20252 20253 20254 20255 20256
-					 
-global yearlist 2023 2024 2025
+global first_mrip_year 2023
+global last_mrip_year 2025
+numlist "$first_mrip_year/$last_mrip_year"
+global yearlist  `r(numlist)'
 global wavelist 1 2 3 4 5 6
 
 * set the baseline year and projection year numbers-at-age globals 
@@ -135,6 +137,7 @@ loc processMRIP = 1		 			// deal with casing MRIP data
 loc assemblemriplists = 1		 	// deal with casing MRIP data
 
 loc estimate_dtrips = 1				// Estimate Directed Trips 
+loc pull_MRIP = 1		 		// Pull MRIP data
 loc costs_per_trip = 1  			// Create Distributions of costs per trip (run 1x)
 loc draw_angler_preferences = 1		// Create draw of angler preference parameters (run 1x)
 loc catch_per_trip1 = 1				// Part 1 of catch per trip
@@ -168,9 +171,17 @@ if `pull_assessment' {
 	do "$input_code_cd\get_assessment_from_gdrive.do"
 }
 
+// 0) Pull MRIP data from Oracle (takes a while).
+
+if `pull_MRIP' {
+	di "Pulling MRIP data from oracle"
+		rscript using "$input_code_cd\get_mrip_oracle.R", args($first_mrip_year $last_mrip_year)
+
+}
 
 
-// 1) Pull the MRIP data
+
+// 1) Process MRIP data
 
 
 if `processMRIP' {

--- a/Code/pre_sim/tidyup_mrip_data_fromR.do
+++ b/Code/pre_sim/tidyup_mrip_data_fromR.do
@@ -21,7 +21,13 @@ foreach l in $catchlist $triplist $b2list $sizelist {
 	foreach var of varlist year wave st{
 		destring `var', replace
 	}
-	
+  /*handle string to stata date format */
+  gen double m2=date(mrip_pull_date, "MDY")
+  format m2 %td
+  assert m2~=.
+	drop mrip_pull_date
+	rename m2 mrip_pull_date
+
 	/* filter based on the global yr_wvs */
 	
 	gen yr_wave=year*10+wave	

--- a/Code/pre_sim/tidyup_mrip_data_fromR.do
+++ b/Code/pre_sim/tidyup_mrip_data_fromR.do
@@ -1,13 +1,23 @@
-* Handle strings and such 
-
+/* Tidyup mrip data that comes from R's tacklebox*/
+/* In the data processing chain, this runs after 
+	rscript using "$input_code_cd\get_mrip_oracle.R", args($first_mrip_year $last_mrip_year)
+	
+Inputs -- mrip trip, catch, size, sizeb2 files
+Outputs -- same, with these modifications:
+	strat_id psu_id id_code zip are forced to strings
+	year wave st are forced to numeric
+	
+	Filterned to include yearwave patterns from $yr_wvs in the model_wrapper.do file.	
+*/
 
 foreach l in $catchlist $triplist $b2list $sizelist {
 
 	use `l', clear
+	/* enforce certain variables as strings */
 	foreach var of varlist strat_id psu_id id_code zip{
 		cap tostring `var', replace
 	}
-
+	/* enforce other variables as numeric */
 	foreach var of varlist year wave st{
 		destring `var', replace
 	}

--- a/Code/pre_sim/tidyup_mrip_data_fromR.do
+++ b/Code/pre_sim/tidyup_mrip_data_fromR.do
@@ -1,0 +1,17 @@
+* Handle strings and such 
+
+
+foreach l in $catchlist $triplist $b2list $sizelist {
+
+	use `l', clear
+	foreach var of varlist strat_id psu_id id_code zip{
+		cap tostring `var', replace
+	}
+
+	foreach var of varlist year wave st{
+		destring `var', replace
+	}
+
+
+save `l', replace
+}

--- a/Code/pre_sim/tidyup_mrip_data_fromR.do
+++ b/Code/pre_sim/tidyup_mrip_data_fromR.do
@@ -11,7 +11,16 @@ foreach l in $catchlist $triplist $b2list $sizelist {
 	foreach var of varlist year wave st{
 		destring `var', replace
 	}
-
-
+	
+	/* filter based on the global yr_wvs */
+	
+	gen yr_wave=year*10+wave	
+	gen yrwave_keep=0
+	qui foreach l of global yr_wvs{
+		replace yrwave_keep=1 if yr_wave==`l'
+	}
+	keep if yrwave_keep==1
+	drop yrwave_keep yr_wave
+	
 save `l', replace
 }


### PR DESCRIPTION
 Initial draft PR 

1. Code to pull trip, catch, size, size_b2 from MRIP using the mriptacklebox
2. Data comes in as a list, constituent parts saved as .dta files with haven.  A little finagling needed to be done with some columns to make sure they are consistent data types.
3. rewrote the dsconcat statements in the stata code. I was lazy here. dsconcat is a user written file that is stacks (concatenates) datasets.  But if you supply just 1 dataset, it just loads that 1dataset into memory. 
4. filter based on the yr_wvs global in model_wrapper. 

Tested the code with:
```
// Control which modules to run (set to 0 to skip)
loc pull_assessment = 0		 		// Pull Assessment data
loc pull_MRIP = 1		 			// Pull MRIP data

loc processMRIP = 0		 			// deal with casing MRIP data
loc assemblemriplists =0		 	// deal with casing MRIP data
loc estimate_dtrips = 1				// Estimate Directed Trips 
loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
loc catch_per_trip1 = 1				// Part 1 of catch per trip
loc copula_in_R = 0					// Copula model in R
loc catch_per_trip2 = 0				// Part 2 of catch per trip
loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
loc prep_cpt_for_dashboard= 0		// prep data for dashboard
loc Rpush_to_gdrive =0 				// Push to google drive in R
loc angler_demogs	=0				// add additonal angler demographics
loc generate_baseline=0				// Generate baseline-year catch-at-length
loc catch_at_length_project=0			// Generate projection-year catch-at-length
loc run_calibration=0						// Run calibration routine in R

```



We should verify the outputs, but I'm not 100% sure how best to do this.  I ran the code to pull 2023 to 2025 MRIP data.

