### PR TITLE
use the developer_setup to avoid hard-coded directories.

### DIFF
--- a/Code/sim/R code wrapper.R
+++ b/Code/sim/R code wrapper.R
@@ -32,6 +32,7 @@ conflicts_prefer(dplyr::count)
 
 #Set up R globals for input/output data and code scripts
 code_cd=here("Code", "sim")
+source(here("Code", "helpers", "developer_setup.R"))
 
 #Data folders
   #input miscellaneous - contains:
@@ -43,7 +44,7 @@ code_cd=here("Code", "sim")
   #n_choice_occasions - stores # of choice occasions per day from calibration
   #calib_catch_draws - stores catch-per-trip datasets (currently the same for calibration and projection year)
 
-final_process_data_cd="E:/Lou_projects/groundfishRDM/2027_mgt_cycle"
+final_process_data_cd=gf.data.dir
 final_process_outcomes_cd=file.path(final_process_data_cd, "base_outcomes")
 final_process_choice_occasions_cd=file.path(final_process_data_cd,"n_choice_occasions")
 final_process_misc_cd=file.path(final_process_data_cd,"miscellaneous")


### PR DESCRIPTION
``MRIP code wrapper.R`` had a hard-coded directory.

This uses the ``developer_setup.R`` file to set the ``final_process_cd`` directory.  

```
# from the developer_setup.R file
stopifnot(developer %in% c("TP", "LCH", "ML", "KB"))
if (developer=="LCH"){
  gf.data.dir<-"E:/Lou_projects/groundfishRDM/2027_mgt_cycle"
} else if (developer %in% c("TP","ML", "KB")){
  dir.create(here("Data","2027_mgt_cycle"), showWarnings = TRUE, recursive=TRUE)
  gf.data.dir<-here("Data","2027_mgt_cycle")
}
```

I flagged @kimberly-bastille for review, but I'm not 100% sure if she uses this code.