### PR TITLE
Catch at length for dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,13 @@
 .Ruserdata
 .secrets
 .csv
-
 /Data
 /data-raw
 /output
 /saved_regs
-
 **/.env
 **/*.env
 *.stswp
 /Code/pre_sim/logs
+directed_trips_after.csv
+directed_trips_before.csv

--- a/Code/pre_sim/catch_at_length_calibration.do
+++ b/Code/pre_sim/catch_at_length_calibration.do
@@ -376,7 +376,7 @@ sort draw season species l
 gen n_ab1=ab1*prop_ab1
 gen n_b2=b2*prop_b2
 gen n_fish=n_ab1+n_b2
-
+save "$misc_data_cd\rdb_cat_len.dta", replace // save file for processing catch at at length for dashboard
 drop prop_ab1 prop_b2 n_ab1 n_b2
 
 * fit catch-at-lengths to gamma distribution 

--- a/Code/pre_sim/catch_at_length_calibration.do
+++ b/Code/pre_sim/catch_at_length_calibration.do
@@ -313,7 +313,7 @@ sort  season species l_cm_bin
 * merge harvest lengths to discards lengths
 merge 1:1 l_cm_bin species season using `b2'
 
-save "$misc_data_cd\rdb_raw_cat_len.dta", replace // save raw discards and harvest at length for dashboard
+
 
 sort species  season l
 
@@ -376,7 +376,7 @@ sort draw season species l
 gen n_ab1=ab1*prop_ab1
 gen n_b2=b2*prop_b2
 gen n_fish=n_ab1+n_b2
-save "$misc_data_cd\rdb_cat_len.dta", replace // save file for processing catch at at length for dashboard
+
 drop prop_ab1 prop_b2 n_ab1 n_b2
 
 * fit catch-at-lengths to gamma distribution 

--- a/Code/pre_sim/catch_at_length_calibration.do
+++ b/Code/pre_sim/catch_at_length_calibration.do
@@ -313,6 +313,8 @@ sort  season species l_cm_bin
 * merge harvest lengths to discards lengths
 merge 1:1 l_cm_bin species season using `b2'
 
+save "$misc_data_cd\rdb_raw_cat_len.dta", replace // save raw discards and harvest at length for dashboard
+
 sort species  season l
 
 gen panel_var=species+"_"+season

--- a/Code/pre_sim/catch_at_length_calibration.do
+++ b/Code/pre_sim/catch_at_length_calibration.do
@@ -313,8 +313,6 @@ sort  season species l_cm_bin
 * merge harvest lengths to discards lengths
 merge 1:1 l_cm_bin species season using `b2'
 
-
-
 sort species  season l
 
 gen panel_var=species+"_"+season

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -347,7 +347,7 @@ if `generate_baseline'{
 
 		}
 		//Process catch at length and format it for the rec dashboard
-if `prep_cal_for_dashboard'{
+if `prep_catch_at_length_for_dash'{
     	di "Processing and formatting catch-at-length for dashboard"
 
 		do "$input_code_cd\rdb_catch_at_length.do"
@@ -355,8 +355,8 @@ if `prep_cal_for_dashboard'{
 
 		}
 		//run this script in R to read in the catch at length processed for the rec dashboard, save it as an Rds, and push it to Google Drive
-if `Rpush_cal_to_gdrive'{
-    	di "Pushing rec dashboard catch at length data to gdrive using R" 
+if `Rpush_catch_at_length_to_gdrive'{
+    	di "Pushing rec dashboard catch at length data to gdrive using R"
 
 		rscript using "$input_code_cd\rdb_catch_at_len_to_drive.R"
 	    di "Rec dashboard catch at length data pushed to gdrive " 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -181,8 +181,8 @@ loc prep_cpt_for_dashboard= 1		// prep data for dashboard
 loc Rpush_cpt_to_gdrive =1 			// Push to google drive in R
 loc angler_demogs	=1				// add additonal angler demographics
 loc generate_baseline=1				// Generate baseline-year catch-at-length
-loc prep_cal_for_dashboard= 1		// Prep catch at length data for dashboard
-loc Rpush_cal_to_gdrive =1 			// Push to google drive in R
+loc prep_catch_at_length_for_dash= 1		// Prep catch at length data for dashboard
+loc Rpush_catch_at_length_to_gdrive =1 			// Push catch at length data to  google drive in R
 loc catch_at_length_project=1			// Generate projection-year catch-at-length
 loc run_calibration=1						// Run calibration routine in R
 

--- a/Code/pre_sim/model_wrapper.do
+++ b/Code/pre_sim/model_wrapper.do
@@ -142,9 +142,11 @@ loc copula_in_R = 1					// Copula model in R
 loc catch_per_trip2 = 1				// Part 2 of catch per trip
 loc compare_calibration_MRIP = 1	// compare calibration output to MRIP
 loc prep_cpt_for_dashboard= 1		// prep data for dashboard
-loc Rpush_to_gdrive =1 				// Push to google drive in R
+loc Rpush_cpt_to_gdrive =1 			// Push to google drive in R
 loc angler_demogs	=1				// add additonal angler demographics
 loc generate_baseline=1				// Generate baseline-year catch-at-length
+loc prep_cal_for_dashboard= 1		// Prep catch at length data for dashboard
+loc Rpush_cal_to_gdrive =1 			// Push to google drive in R
 loc catch_at_length_project=1			// Generate projection-year catch-at-length
 loc run_calibration=1						// Run calibration routine in R
 
@@ -261,7 +263,7 @@ if `prep_cpt_for_dashboard'{
 
 		}
 		//run this script in R to read in the catch per trip processed for the rec dashboard, save it as an Rds, and push it to Google Drive
-if `Rpush_to_gdrive'{
+if `Rpush_cpt_to_gdrive'{
     	di "Pushing rec dashboard data to gdrive using R" 
 
 		rscript using "$input_code_cd\rdb_catch_per_trip_to_drive.R"
@@ -284,6 +286,22 @@ if `generate_baseline'{
     	di "Baseline catch-at-length generated " 
 
 		}
+		//Process catch at length and format it for the rec dashboard
+if `prep_cal_for_dashboard'{
+    	di "Processing and formatting catch-at-length for dashboard"
+
+		do "$input_code_cd\rdb_catch_at_length.do"
+    	di "Processing and formatting catch-at-length for dashboard done"
+
+		}
+		//run this script in R to read in the catch at length processed for the rec dashboard, save it as an Rds, and push it to Google Drive
+if `Rpush_cal_to_gdrive'{
+    	di "Pushing rec dashboard catch at length data to gdrive using R" 
+
+		rscript using "$input_code_cd\rdb_catch_at_len_to_drive.R"
+	    di "Rec dashboard catch at length data pushed to gdrive " 
+
+}		
 // 10) Generate projection-year catch-at-length, incorporating the stock assessment data
 if `catch_at_length_project'{
 		di "Generating projection year catch-at-length" 

--- a/Code/pre_sim/rdb_catch_at_len_to_drive.R
+++ b/Code/pre_sim/rdb_catch_at_len_to_drive.R
@@ -1,0 +1,55 @@
+#This code reads in a catch at length dta for the recDST data dashboard and uploads it to Google drive as an Rds
+
+
+#Load libraries
+library(tidyverse)
+library(haven)
+library(glue)
+library(googledrive)
+library(here)
+
+here::i_am("Code/pre_sim/rdb_catch_at_len_to_drive.R")
+source(here("Code", "helpers", "developer_setup.R"))
+
+output_folder<-file.path(gf.data.dir, "miscellaneous")
+
+input_file <- file.path(gf.data.dir,"miscellaneous","rdb_cat_len.dta")
+
+# Read in my .dta file
+rdb_catch_at_length <- read_dta(input_file)
+
+# Save the data version
+file_date <- rdb_catch_at_length$data_version[1]
+SimCPTSaveFile<-glue("rdb_catch_at_length_{file_date}")
+
+# convert character date to a date variable
+rdb_catch_at_length$data_version<-as.Date(rdb_catch_at_length$data_version)
+
+# Save dataframe as Rds
+write_rds(rdb_catch_at_length, file=file.path(output_folder,glue("{SimCPTSaveFile}.Rds")))
+
+
+# Connect to Google Drive
+# NOTE: Relies on cached credentials in .secrets. Will prompt interactive auth if missing or expired.
+drive_auth(cache = here(".secrets"), email = TRUE)
+
+# Output folder on google drive
+miscellaneous_path <-file.path("socialsci","RecreationalDST","2027_management_cycle_data",
+                               "groundfishRDM","miscellaneous")
+
+folder_info <- drive_get(
+  path = miscellaneous_path,
+  shared_drive = "NMFS NEC READ SSB"
+)
+miscellaneous_path<-folder_info$id
+
+
+#Put the catch per trip Rds on google drive
+drive_upload(
+  media = file.path(output_folder,glue("{SimCPTSaveFile}.Rds")),
+  path = as_id(miscellaneous_path),
+  name = glue("{SimCPTSaveFile}.Rds"),
+  overwrite = TRUE
+)
+
+

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -24,75 +24,49 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 
 
 
-
-//medians of the observed and fitted probabilities for catch at length (doesn't have harvest and discards at length)
-// observed is same as if you generated from rdb_cat_len.dta like above but this one trims the rows at the ends of the length distribution that are 0's
+//format for dashboard - medians of 101 draws of the observed and fitted probabilities for catch at length 
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
-
-collapse (median) observed_prob fitted_prob, by(season species length)
-gen inches=length/2.54
-gen inches_r = round(inches)
-* CANT tostring the length in inches because now it has a bunch of decimals. do I round? round up? ask lou 
-tostring inches_r, gen(length1)
-gen metric = season+" at "+length1+" "+"in"
-gen units="proportion of catch" 
-
-
-//egen sum=sum(observed_prob), by(species season ) 
-//egen sum1=sum(fitted_prob), by(species season ) 
-
-
-twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
-
-twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
-
-
-//collapse to inches bins
-collapse (sum) observed_prob fitted_prob, by(season species inches_r)
-tostring inches_r, gen(length1)
-gen metric = season+" at "+length1+" "+"in"
-gen units="proportion of catch" 
-rename inches_r length 
-
-//now the fitted doesn't look smooth. need to switch to inches in the cal calibration do
-twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
-
-twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
-
-
-
-
-
-//for dashboard
-
-import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
-
 
 //observed probability
 preserve
 collapse (median) observed_prob, by(season species length)
+//convert to inches
 replace length=length/2.54
-tostring length, gen(length1)
-gen metric = season+" at "+length1+" "+"in"
-drop season length
-gen units="observed proportion of catch at length" 
+//reduce number of decimals for the metric column
+gen len_r = round(length, 0.1)
+tostring len_r, replace format("%12.1f") force
+gen metric = season+" "+len_r
+drop season len_r
+gen units="observed proportion of catch" 
 rename observed_prob value
-
 tempfile obs
 save `obs', replace 
 restore
 
 //fitted (smoothed) probability
 collapse (median) fitted_prob, by(season species length)
+//convert to inches
 replace length=length/2.54
-tostring length, gen(length1)
-gen metric = season+" at "+length1+" "+"in"
-drop season length
-gen units="fitted proportion of catch at length" 
+//reduce number of decimals for the metric column
+gen len_r = round(length, 0.1)
+tostring len_r, replace format("%12.1f") force
+gen metric = season+" "+len_r
+drop season len_r
+gen units="fitted proportion of catch" 
 rename fitted_prob value
 
 //stack the fitted and observed probabilities
 append using `obs'
+
+/*check to make sure figures look right
+split metric, gen(season)
+
+twoway (line value length if species=="cod" & units=="observed proportion of catch") (line value length if species=="cod"  & units=="fitted proportion of catch"), by(season1, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)") ytitle("Proportion")
+ 
+twoway (line value length if species=="hadd" & units=="observed proportion of catch") (line value length if species=="hadd"  & units=="fitted proportion of catch"), by(season1, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)") ytitle("Proportion")
+
+drop season1-season4
+*/
 
 
 // add columns for common, species_itis
@@ -100,7 +74,7 @@ gen common = "atlanticcod" if species=="cod"
 replace common = "haddock" if species=="hadd"
 gen species_itis = 164712 if species=="cod"
 replace species_itis = 164744 if species=="hadd"
-drop species
+drop species length
 
 // Update this 
 gen data_version="2026-06-29"
@@ -109,12 +83,47 @@ gen source="model intermediate"
 gen stock_abbrev="WGOM"
 gen fishery= "NE Groundfish"
 
-//should year go in here?
+//should year go in?
 gen year=2025
 
+// kim fine with extracting the lengths in inches that only have one decimal place in the metric column
 
-order fishery common species_itis stock_abbrev data_version year season metric value units source
+order fishery common species_itis stock_abbrev data_version year metric value units source
 
+
+
+
+
+
+
+
+
+//old
+
+//visualizing the data - medians of 101 draws of the observed and fitted probabilities for catch at length 
+import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
+
+collapse (median) observed_prob fitted_prob, by(season species length)
+gen inches=length/2.54
+//reduce number of decimals for the metric column
+gen inches_r = round(inches, 0.1)
+tostring inches_r, replace format("%12.1f") force
+gen metric = season+" at "+inches_r+" "+"in"
+gen units="proportion of catch" 
+
+
+//egen sum=sum(observed_prob), by(species season ) 
+//egen sum1=sum(fitted_prob), by(species season ) 
+
+//cm
+twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
+
+twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
+
+//inches
+twoway line observed_prob fitted_prob inches if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
+
+twoway line observed_prob fitted_prob inches if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -35,7 +35,7 @@ replace species_itis = 164744 if species=="hadd"
 drop species
 
 
-*test
+*test 1
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -1,0 +1,43 @@
+*********** WGOM COD & HADDOCK CATCH AT LENGTH ***********
+
+/*
+This code pulls the median of the 101 draws of simulated mean catch at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM). 
+
+This code cleans the simulated catch at length data compiled in catch_at_length_calibration.do and saved in baseline_catch_at_length_observed.csv and formats the data for use in the rec dashboard. 
+
+
+ Name: rdb__catch_at_length.do
+ Inputs: baseline_catch_at_length_observed.csv
+ Outputs: rdb_sim_catch_at_length.dta
+ Description: Grabs the median number of fish caught at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM), based on 101 random draws of mean simulated total catch.
+ General strategy:
+  1. Read in data
+  2. Collapse data to get median number of fish caught at length for Cod and then Haddock
+  3. Add descriptive columns for dashboard
+  4. Run rdb_catch_at_length_to_drive.R to push the processed data to Google Drive as an Rds
+  
+*/
+
+
+import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
+
+
+collapse (median) n_fish, by(length season species)
+tostring length, gen(length1)
+gen metric = length1+" "+"cm"
+gen units="number of fish" 
+
+// add columns for common, species_itis
+gen common = "atlanticcod" if species=="cod"
+replace common = "haddock" if species=="hadd"
+gen species_itis = 164712 if species=="cod"
+replace species_itis = 164744 if species=="hadd"
+drop species
+
+
+
+
+
+
+
+

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -104,6 +104,9 @@ gen source="model intermediate"
 gen stock_abbrev="WGOM"
 gen fishery= "NE Groundfish"
 
+//get rid of var label on value 
+label variable value ""
+
 //should year go in?
 gen year=2025
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -29,17 +29,17 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 // observed is same as if you generated from rdb_cat_len.dta like above but this one trims the rows at the ends of the length distribution that are 0's
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
-
 collapse (median) observed_prob fitted_prob, by(season species length)
 gen inches=length/2.54
+gen inches_r = round(inches)
 * CANT tostring the length in inches because now it has a bunch of decimals. do I round? round up? ask lou 
-tostring inches, gen(length1)
+tostring inches_r, gen(length1)
 gen metric = season+" at "+length1+" "+"in"
 gen units="proportion of catch" 
 
 
-egen sum=sum(observed_prob), by(species season ) 
-egen sum1=sum(fitted_prob), by(species season ) 
+//egen sum=sum(observed_prob), by(species season ) 
+//egen sum1=sum(fitted_prob), by(species season ) 
 
 
 twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
@@ -47,6 +47,17 @@ twoway line observed_prob fitted_prob length if species=="cod", sort by(season, 
 twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
 
 
+//collapse to inches bins
+collapse (sum) observed_prob fitted_prob, by(season species inches_r)
+tostring inches_r, gen(length1)
+gen metric = season+" at "+length1+" "+"in"
+gen units="proportion of catch" 
+rename inches_r length 
+
+//now the fitted doesn't look smooth. need to switch to inches in the cal calibration do
+twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
+
+twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -22,113 +22,6 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 
 // change everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
 
-//raw observed numbers released at length on headboats and observed harvest at length from MRIP
-u "$misc_data_cd\rdb_raw_cat_len.dta", clear 
-
-rename l_cm_bin length
-rename nfish_ab1 harvest 
-rename nfish_b2 discards
-
-replace season="summer" if season=="sum"
-replace season="winter" if season=="win"
-
-replace harvest = 0 if missing(harvest)
-replace discards = 0 if missing(discards)
-
-sort species season length
-
-//harvets and discards in same plot doesn't work
-twoway line harvest discards length if species=="cod", sort by(season, title("Raw cod harvest & discards at length, #'s of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
-twoway line harvest discards length if species=="hadd", sort by(season, title("Raw hadd harvest & discards at length, #'s of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
-
-//cod
-twoway line discards length if species=="cod", sort by(season, title("Raw cod discards at length, #'s of fish")) xtitle("Length (cm)")
-twoway line harvest length if species=="cod", sort by(season, title("Raw cod harvest at length, #'s of fish")) xtitle("Length (cm)")
-
-//hadd
-twoway line discards length if species=="hadd", sort by(season, title("Raw hadd discards at length, #'s of fish")) xtitle("Length (cm)")
-twoway line harvest length if species=="hadd", sort by(season, title("Raw hadd harvest at length, #'s of fish")) xtitle("Length (cm)")
-
-
-//
-egen har_total=sum(harvest), by(species season) 
-egen disc_total=sum(discards), by(species season) 
-gen h_prop=harvest/har_total
-gen d_prop=discards/disc_total
-twoway line h_prop d_prop length if species=="cod" & season=="summer"
-
-twoway line harvest discards length if species=="cod" & season=="summer"
-twoway line harvest discards length if species=="cod" & season=="winter"
-twoway line harvest discards length if species=="hadd" & season=="summer"
-twoway line harvest discards length if species=="hadd" & season=="winter"
-
-
-
-
-//median numbers of fish harvested, discarded, and caught at length. proportions are multiplied by 101 draws of total harvest and total discards
-u "$misc_data_cd\rdb_cat_len.dta", clear // file for processing catch at at length for dashboard
-
-rename l_cm_bin length
-rename n_ab1 harvest 
-rename n_b2 discards
-rename n_fish catch
-
-collapse (median) harvest discards catch, by(season species length)
-tostring length, gen(length1)
-gen metric = length1+" "+"cm"
-gen units="number of fish"
-
-//all 3
-twoway line harvest discards catch length if species=="cod", sort by(season, title("Cod catch at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
-
-twoway line harvest discards catch length if species=="hadd", sort by(season, title("Hadd catch at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
-
-//harvest discards only
-twoway line harvest discards length if species=="cod", sort by(season, title("Cod harvest&discards at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
-
-twoway line harvest discards length if species=="hadd", sort by(season, title("Hadd harvest&discards at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
-
-//catch only
-twoway line catch length if species=="cod", sort by(season, title("Cod catch at length numbers of fish")) xtitle("Length (cm)")
-
-twoway line catch length if species=="hadd", sort by(season, title("Hadd catch at length numbers of fish")) xtitle("Length (cm)")
-
-
-
-//old
-twoway line harvest discards length if species=="cod" & season=="summer"
-twoway line harvest discards length if species=="cod" & season=="winter"
-twoway line harvest discards length if species=="hadd" & season=="summer"
-twoway line harvest discards length if species=="hadd" & season=="winter"
-
-
-
-
-
-//median probability catch at length - and has probabilities for harvest and discards at length (constant across draws)
-u "$misc_data_cd\rdb_cat_len.dta", clear 
-
-//probabilities for catch at length
-gen tot_cat=ab1+b2
-gen prop_cal=n_fish/tot_cat
-
-rename l_cm_bin length
-
-collapse (median) prop_cal prop_ab1 prop_b2, by(season species length)
-tostring length, gen(length1)
-gen metric = length1+" "+"cm"
-gen units="proportion of catch (observed)" 
-
-twoway line prop_ab1 prop_b2 prop_cal length if species=="cod", sort by(season, title("Cod catch at length proportions")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
-
-twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd", sort by(season, title("Hadd catch at length proportions")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
-
-
-egen sum=sum(prop_cal), by(species season ) 
-
-
-
-
 
 
 
@@ -136,18 +29,17 @@ egen sum=sum(prop_cal), by(species season )
 // observed is same as if you generated from rdb_cat_len.dta like above but this one trims the rows at the ends of the length distribution that are 0's
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
+
 collapse (median) observed_prob fitted_prob, by(season species length)
-replace length=length/2.54
-tostring length, gen(length1)
-gen metric = season+" at "+length1+" "+"cm"
+gen inches=length/2.54
+* CANT tostring the length in inches because now it has a bunch of decimals. do I round? round up? ask lou 
+tostring inches, gen(length1)
+gen metric = season+" at "+length1+" "+"in"
 gen units="proportion of catch" 
+
 
 egen sum=sum(observed_prob), by(species season ) 
 egen sum1=sum(fitted_prob), by(species season ) 
-
-* delete these
-//twoway line observed_prob length if species=="cod" & season=="summer"
-//twoway line observed_prob fitted_prob length if species=="cod" & season=="summer"
 
 
 twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
@@ -156,35 +48,40 @@ twoway line observed_prob fitted_prob length if species=="hadd", sort by(season,
 
 
 
-// add columns for common, species_itis
-gen common = "atlanticcod" if species=="cod"
-replace common = "haddock" if species=="hadd"
-gen species_itis = 164712 if species=="cod"
-replace species_itis = 164744 if species=="hadd"
-drop species
-
-//Update this 
-gen data_version="2026-06-29"
-
-gen source="model intermediate"
-gen stock_abbrev="WGOM"
-gen fishery= "NE Groundfish"
-
-order fishery common species_itis stock_abbrev state mode data_version year season wave month metric value units source
 
 
 
 
+//for dashboard
 
-//DELETE
-//stuff from thurs. has some of the dashboard columns
-//import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
+import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
-collapse (median) n_fish, by(length season species)
+
+//observed probability
+preserve
+collapse (median) observed_prob, by(season species length)
+replace length=length/2.54
 tostring length, gen(length1)
-gen metric = length1+" "+"cm"
-gen units="number of fish" 
-rename n_fish value
+gen metric = season+" at "+length1+" "+"in"
+drop season length
+gen units="observed proportion of catch at length" 
+rename observed_prob value
+
+tempfile obs
+save `obs', replace 
+restore
+
+//fitted (smoothed) probability
+collapse (median) fitted_prob, by(season species length)
+replace length=length/2.54
+tostring length, gen(length1)
+gen metric = season+" at "+length1+" "+"in"
+drop season length
+gen units="fitted proportion of catch at length" 
+rename fitted_prob value
+
+//stack the fitted and observed probabilities
+append using `obs'
 
 
 // add columns for common, species_itis
@@ -194,27 +91,21 @@ gen species_itis = 164712 if species=="cod"
 replace species_itis = 164744 if species=="hadd"
 drop species
 
-graph bar value if common=="atlanticcod", over(length) by(season) ytitle("number of fish")  scheme(stmono1) 
-
-graph bar value if common=="haddock", over(length) ytitle("number of fish")  scheme(stmono1) 
-
-
-//Update this 
+// Update this 
 gen data_version="2026-06-29"
 
-gen wave=.
-gen state=.
-gen mode=.
-gen year=.
-gen month=.
 gen source="model intermediate"
 gen stock_abbrev="WGOM"
 gen fishery= "NE Groundfish"
 
+//should year go in here?
+gen year=2025
 
-drop length length1
 
-order fishery common species_itis stock_abbrev state mode data_version year season wave month metric value units source
+order fishery common species_itis stock_abbrev data_version year season metric value units source
+
+
+
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -35,7 +35,7 @@ replace species_itis = 164744 if species=="hadd"
 drop species
 
 
-
+*test
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -19,30 +19,6 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 */
 
 
-//To test change everything to 0 in execution control in model wrapper other than prep_cal_for_dashboard and Rpush_cal_to_gdrive if you've already run the catch-at-length calibration code you will have what you need. And if not you can save the baseline_catch_at_length.csv from the misc folder locally
-
-/*
-loc pull_assessment = 0		 		// Pull Assessment data
-loc processMRIP = 0		 			// deal with casing MRIP data
-loc assemblemriplists = 0		 	// deal with casing MRIP data
-
-loc estimate_dtrips = 0				// Estimate Directed Trips 
-loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
-loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
-loc catch_per_trip1 = 0				// Part 1 of catch per trip
-loc copula_in_R = 0					// Copula model in R
-loc catch_per_trip2 = 0				// Part 2 of catch per trip
-loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
-loc prep_cpt_for_dashboard= 0		// prep data for dashboard
-loc Rpush_cpt_to_gdrive =0 			// Push to google drive in R
-loc angler_demogs	=0				// add additonal angler demographics
-loc generate_baseline=0				// Generate baseline-year catch-at-length
-loc prep_cal_for_dashboard= 1		// Prep catch at length data for dashboard
-loc Rpush_cal_to_gdrive =1 			// Push to google drive in R
-loc catch_at_length_project=0			// Generate projection-year catch-at-length
-loc run_calibration=0						// Run calibration routine in R
-*/
-
 
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -23,7 +23,6 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 // change everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
 
 
-
 //format for dashboard - medians of 101 draws of the observed and fitted probabilities for catch at length 
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
@@ -58,7 +57,7 @@ rename fitted_prob value
 //stack the fitted and observed probabilities
 append using `obs'
 
-/*check to make sure figures look right
+/*check to make sure everything looks right
 split metric, gen(season)
 
 twoway (line value length if species=="cod" & units=="observed proportion of catch") (line value length if species=="cod"  & units=="fitted proportion of catch"), by(season1, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)") ytitle("Proportion")
@@ -69,7 +68,7 @@ drop season1-season4
 */
 
 
-// add columns for common, species_itis
+// add columns for dashboard
 gen common = "atlanticcod" if species=="cod"
 replace common = "haddock" if species=="hadd"
 gen species_itis = 164712 if species=="cod"
@@ -86,45 +85,11 @@ gen fishery= "NE Groundfish"
 //should year go in?
 gen year=2025
 
-// kim fine with extracting the lengths in inches that only have one decimal place in the metric column
+// kim fine with extracting the lengths in inches that only have one decimal place from the metric column
 
 order fishery common species_itis stock_abbrev data_version year metric value units source
 
-
-
-
-
-
-
-
-
-//old
-
-//visualizing the data - medians of 101 draws of the observed and fitted probabilities for catch at length 
-import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
-
-collapse (median) observed_prob fitted_prob, by(season species length)
-gen inches=length/2.54
-//reduce number of decimals for the metric column
-gen inches_r = round(inches, 0.1)
-tostring inches_r, replace format("%12.1f") force
-gen metric = season+" at "+inches_r+" "+"in"
-gen units="proportion of catch" 
-
-
-//egen sum=sum(observed_prob), by(species season ) 
-//egen sum1=sum(fitted_prob), by(species season ) 
-
-//cm
-twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
-
-twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
-
-//inches
-twoway line observed_prob fitted_prob inches if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
-
-twoway line observed_prob fitted_prob inches if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (in)")
-
+save "$misc_data_cd\rdb_cat_len.dta.dta", replace 
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -20,10 +20,10 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 
 
 
-// changed everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
+// change everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
 
-//raw observed numbers of fish
-u "$misc_data_cd\rdb_raw_cat_len.dta", clear //  raw discards and harvest numbers at length for dashboard
+//raw observed numbers released at length on headboats and observed harvest at length from MRIP
+u "$misc_data_cd\rdb_raw_cat_len.dta", clear 
 
 rename l_cm_bin length
 rename nfish_ab1 harvest 
@@ -37,34 +37,67 @@ replace discards = 0 if missing(discards)
 
 sort species season length
 
+//harvets and discards in same plot doesn't work
+twoway line harvest discards length if species=="cod", sort by(season, title("Raw cod harvest & discards at length, #'s of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
+twoway line harvest discards length if species=="hadd", sort by(season, title("Raw hadd harvest & discards at length, #'s of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
+
+//cod
+twoway line discards length if species=="cod", sort by(season, title("Raw cod discards at length, #'s of fish")) xtitle("Length (cm)")
+twoway line harvest length if species=="cod", sort by(season, title("Raw cod harvest at length, #'s of fish")) xtitle("Length (cm)")
+
+//hadd
+twoway line discards length if species=="hadd", sort by(season, title("Raw hadd discards at length, #'s of fish")) xtitle("Length (cm)")
+twoway line harvest length if species=="hadd", sort by(season, title("Raw hadd harvest at length, #'s of fish")) xtitle("Length (cm)")
+
+
+//
+egen har_total=sum(harvest), by(species season) 
+egen disc_total=sum(discards), by(species season) 
+gen h_prop=harvest/har_total
+gen d_prop=discards/disc_total
+twoway line h_prop d_prop length if species=="cod" & season=="summer"
+
 twoway line harvest discards length if species=="cod" & season=="summer"
 twoway line harvest discards length if species=="cod" & season=="winter"
-
 twoway line harvest discards length if species=="hadd" & season=="summer"
 twoway line harvest discards length if species=="hadd" & season=="winter"
 
-//cant have discards and harvest numbers on same plot bc harvest is so high for some lengths
 
 
 
-//numbers of fish. this one is multiplied by total harvest and total discards
+//median numbers of fish harvested, discarded, and caught at length. proportions are multiplied by 101 draws of total harvest and total discards
 u "$misc_data_cd\rdb_cat_len.dta", clear // file for processing catch at at length for dashboard
 
-gen tot_cat=ab1+b2
 rename l_cm_bin length
 rename n_ab1 harvest 
 rename n_b2 discards
+rename n_fish catch
 
-collapse (median) harvest discards tot_cat, by(season species length)
+collapse (median) harvest discards catch, by(season species length)
 tostring length, gen(length1)
 gen metric = length1+" "+"cm"
 gen units="number of fish"
 
-//opposite here, discards way higher than harvest
+//all 3
+twoway line harvest discards catch length if species=="cod", sort by(season, title("Cod catch at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
+
+twoway line harvest discards catch length if species=="hadd", sort by(season, title("Hadd catch at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
+
+//harvest discards only
+twoway line harvest discards length if species=="cod", sort by(season, title("Cod harvest&discards at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
+
+twoway line harvest discards length if species=="hadd", sort by(season, title("Hadd harvest&discards at length numbers of fish")) legend(label(1 "Harvest") label(2 "Discards")) xtitle("Length (cm)")
+
+//catch only
+twoway line catch length if species=="cod", sort by(season, title("Cod catch at length numbers of fish")) xtitle("Length (cm)")
+
+twoway line catch length if species=="hadd", sort by(season, title("Hadd catch at length numbers of fish")) xtitle("Length (cm)")
+
+
+
+//old
 twoway line harvest discards length if species=="cod" & season=="summer"
 twoway line harvest discards length if species=="cod" & season=="winter"
-
-//looks good for haddock
 twoway line harvest discards length if species=="hadd" & season=="summer"
 twoway line harvest discards length if species=="hadd" & season=="winter"
 
@@ -72,11 +105,10 @@ twoway line harvest discards length if species=="hadd" & season=="winter"
 
 
 
-//median observed probabilities
-u "$misc_data_cd\rdb_cat_len.dta", clear // file for processing catch at at length for dashboard
+//median probability catch at length - and has probabilities for harvest and discards at length (constant across draws)
+u "$misc_data_cd\rdb_cat_len.dta", clear 
 
-// grab median proportions
-
+//probabilities for catch at length
 gen tot_cat=ab1+b2
 gen prop_cal=n_fish/tot_cat
 
@@ -87,65 +119,63 @@ tostring length, gen(length1)
 gen metric = length1+" "+"cm"
 gen units="proportion of catch (observed)" 
 
+twoway line prop_ab1 prop_b2 prop_cal length if species=="cod", sort by(season, title("Cod catch at length proportions")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
+
+twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd", sort by(season, title("Hadd catch at length proportions")) legend(label(1 "Harvest") label(2 "Discards") label(3 "Catch")) xtitle("Length (cm)")
+
+
 egen sum=sum(prop_cal), by(species season ) 
 
+/// delete
+twoway line prop_ab1 prop_b2 length if species=="cod" & season=="summer"
 twoway line prop_cal length if species=="cod" & season=="summer"
-
 twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="summer"
 twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="winter"
 twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="summer"
 twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="winter"
 
-
+/// delete 
 rename prop_ab1 harvest
 rename prop_b2 discards
-
 //it's bad for cod summer bc over 80% of harvest is one length
 twoway line harvest discards length if species=="cod" & season=="summer"
 twoway line harvest discards length if species=="cod" & season=="winter"
-
 twoway line harvest discards length if species=="hadd" & season=="summer"
 twoway line harvest discards length if species=="hadd" & season=="winter"
 
 
 
-// this is the same numbers as above but trims the ends of the length distribution with 0's
-import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
-collapse (median) observed_prob, by(season species length)
-tostring length, gen(length1)
-gen metric = length1+" "+"cm"
-gen units="proportion of catch (observed)" 
-
-egen sum=sum(observed_prob), by(species season ) 
-
-twoway line observed_prob length if species=="cod" & season=="summer"
 
 
-
-
-//getting the fitted prob
+//medians of the observed and fitted probabilities for catch at length (doesn't have harvest and discards at length)
+// observed is same as if you generated from rdb_cat_len.dta like above but this one trims the rows at the ends of the length distribution that are 0's
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
 collapse (median) observed_prob fitted_prob, by(season species length)
 tostring length, gen(length1)
 gen metric = length1+" "+"cm"
-gen units="proportion of catch (observed)" 
+gen units="proportion of catch" 
 
 egen sum=sum(observed_prob), by(species season ) 
 egen sum1=sum(fitted_prob), by(species season ) 
 
-twoway line observed_prob length if species=="cod" & season=="summer"
-
-twoway line fitted_prob length if species=="cod" & season=="summer"
-twoway line fitted_prob length if species=="hadd" & season=="summer"
-
+* delete these
+//twoway line observed_prob length if species=="cod" & season=="summer"
+//twoway line observed_prob fitted_prob length if species=="cod" & season=="summer"
 
 
+twoway line observed_prob fitted_prob length if species=="cod", sort by(season, title("Cod catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
+
+twoway line observed_prob fitted_prob length if species=="hadd", sort by(season, title("Hadd catch at length")) legend( label(1 "Observed") label(2 "Fitted")) xtitle("Length (cm)")
 
 
 
 
-//stuff from thurs
+
+
+
+
+//stuff from thurs. has some of the dashboard columns
 //import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -126,22 +126,7 @@ twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd", sort by(season,
 
 egen sum=sum(prop_cal), by(species season ) 
 
-/// delete
-twoway line prop_ab1 prop_b2 length if species=="cod" & season=="summer"
-twoway line prop_cal length if species=="cod" & season=="summer"
-twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="summer"
-twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="winter"
-twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="summer"
-twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="winter"
 
-/// delete 
-rename prop_ab1 harvest
-rename prop_b2 discards
-//it's bad for cod summer bc over 80% of harvest is one length
-twoway line harvest discards length if species=="cod" & season=="summer"
-twoway line harvest discards length if species=="cod" & season=="winter"
-twoway line harvest discards length if species=="hadd" & season=="summer"
-twoway line harvest discards length if species=="hadd" & season=="winter"
 
 
 
@@ -152,8 +137,9 @@ twoway line harvest discards length if species=="hadd" & season=="winter"
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
 
 collapse (median) observed_prob fitted_prob, by(season species length)
+replace length=length/2.54
 tostring length, gen(length1)
-gen metric = length1+" "+"cm"
+gen metric = season+" at "+length1+" "+"cm"
 gen units="proportion of catch" 
 
 egen sum=sum(observed_prob), by(species season ) 
@@ -170,14 +156,29 @@ twoway line observed_prob fitted_prob length if species=="hadd", sort by(season,
 
 
 
+// add columns for common, species_itis
+gen common = "atlanticcod" if species=="cod"
+replace common = "haddock" if species=="hadd"
+gen species_itis = 164712 if species=="cod"
+replace species_itis = 164744 if species=="hadd"
+drop species
+
+//Update this 
+gen data_version="2026-06-29"
+
+gen source="model intermediate"
+gen stock_abbrev="WGOM"
+gen fishery= "NE Groundfish"
+
+order fishery common species_itis stock_abbrev state mode data_version year season wave month metric value units source
 
 
 
 
 
+//DELETE
 //stuff from thurs. has some of the dashboard columns
 //import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
-
 
 collapse (median) n_fish, by(length season species)
 tostring length, gen(length1)

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -1,30 +1,52 @@
 *********** WGOM COD & HADDOCK CATCH AT LENGTH ***********
 
 /*
-This code pulls the median of 101 draws of simulated catch at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM). We take the observed probabilities of catch at length and the smoothed catch at length probability distribution. We also take the raw observed numbers of fish discarded at length and harvested at length (unweighted for cod and weighted for haddock). 
+This code pulls the median of 101 draws of simulated catch at length probabilities for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM). We take the observed probabilities of catch at length and the fitted (smoothed) probabilities of catch at length in inches. 
 
-This code cleans the simulated catch at length data compiled in catch_at_length_calibration.do and saved in baseline_catch_at_length_observed.csv and formats the data for use in the rec dashboard. 
+This code cleans the simulated catch at length data compiled in catch_at_length_calibration.do and saved in baseline_catch_at_length.csv and formats the data for use in the recDST data dashboard. 
 
 
- Name: rdb__catch_at_length.do
+ Name: rdb_catch_at_length.do
  Inputs: baseline_catch_at_length_observed.csv
- Outputs: rdb_sim_catch_at_length.dta
- Description: Grabs the median number of fish caught at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM), based on 101 random draws of mean simulated total catch.
+ Outputs: rdb_cat_len.dta.dta
+ Description: Grabs the median proportions caught at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM), based on 101 random draws of mean simulated total catch.
  General strategy:
   1. Read in data
-  2. Collapse data to get median number of fish caught at length for Cod and then Haddock
+  2. Collapse data to get median probabilities caught at length (observed and fitted) for Cod and Haddock
   3. Add descriptive columns for dashboard
-  4. Run rdb_catch_at_length_to_drive.R to push the processed data to Google Drive as an Rds
+  4. Run rdb_catch_at_len_to_drive.R to push the processed data to Google Drive as an Rds
   
 */
 
 
+//To test change everything to 0 in execution control in model wrapper other than prep_cal_for_dashboard and Rpush_cal_to_gdrive if you've already run the catch-at-length calibration code you will have what you need. And if not you can save the baseline_catch_at_length.csv from the misc folder locally
 
-// change everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
+/*
+loc pull_assessment = 0		 		// Pull Assessment data
+loc processMRIP = 0		 			// deal with casing MRIP data
+loc assemblemriplists = 0		 	// deal with casing MRIP data
+
+loc estimate_dtrips = 0				// Estimate Directed Trips 
+loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
+loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
+loc catch_per_trip1 = 0				// Part 1 of catch per trip
+loc copula_in_R = 0					// Copula model in R
+loc catch_per_trip2 = 0				// Part 2 of catch per trip
+loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
+loc prep_cpt_for_dashboard= 0		// prep data for dashboard
+loc Rpush_cpt_to_gdrive =0 			// Push to google drive in R
+loc angler_demogs	=0				// add additonal angler demographics
+loc generate_baseline=0				// Generate baseline-year catch-at-length
+loc prep_cal_for_dashboard= 1		// Prep catch at length data for dashboard
+loc Rpush_cal_to_gdrive =1 			// Push to google drive in R
+loc catch_at_length_project=0			// Generate projection-year catch-at-length
+loc run_calibration=0						// Run calibration routine in R
+*/
 
 
-//format for dashboard - medians of 101 draws of the observed and fitted probabilities for catch at length 
 import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
+
+*Take medians of 101 draws of the observed and fitted probabilities for catch at length 
 
 //observed probability
 preserve
@@ -68,7 +90,7 @@ drop season1-season4
 */
 
 
-// add columns for dashboard
+// Add columns for dashboard
 gen common = "atlanticcod" if species=="cod"
 replace common = "haddock" if species=="hadd"
 gen species_itis = 164712 if species=="cod"
@@ -90,9 +112,6 @@ gen year=2025
 order fishery common species_itis stock_abbrev data_version year metric value units source
 
 save "$misc_data_cd\rdb_cat_len.dta.dta", replace 
-
-
-
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -26,6 +26,8 @@ collapse (median) n_fish, by(length season species)
 tostring length, gen(length1)
 gen metric = length1+" "+"cm"
 gen units="number of fish" 
+rename n_fish value
+
 
 // add columns for common, species_itis
 gen common = "atlanticcod" if species=="cod"
@@ -34,8 +36,27 @@ gen species_itis = 164712 if species=="cod"
 replace species_itis = 164744 if species=="hadd"
 drop species
 
+graph bar value if common=="atlanticcod", over(length) by(season) ytitle("number of fish")  scheme(stmono1) 
 
-*test 1
+graph bar value if common=="haddock", over(length) ytitle("number of fish")  scheme(stmono1) 
+
+
+//Update this 
+gen data_version="2026-06-29"
+
+gen wave=.
+gen state=.
+gen mode=.
+gen year=.
+gen month=.
+gen source="model intermediate"
+gen stock_abbrev="WGOM"
+gen fishery= "NE Groundfish"
+
+
+drop length length1
+
+order fishery common species_itis stock_abbrev state mode data_version year season wave month metric value units source
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -111,7 +111,7 @@ gen year=2025
 
 order fishery common species_itis stock_abbrev data_version year metric value units source
 
-save "$misc_data_cd\rdb_cat_len.dta.dta", replace 
+save "$misc_data_cd\rdb_cat_len.dta", replace 
 
 
 

--- a/Code/pre_sim/rdb_catch_at_length.do
+++ b/Code/pre_sim/rdb_catch_at_length.do
@@ -1,7 +1,7 @@
 *********** WGOM COD & HADDOCK CATCH AT LENGTH ***********
 
 /*
-This code pulls the median of the 101 draws of simulated mean catch at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM). 
+This code pulls the median of 101 draws of simulated catch at length for Atlantic Cod and Haddock in the Western Gulf of Maine (WGOM). We take the observed probabilities of catch at length and the smoothed catch at length probability distribution. We also take the raw observed numbers of fish discarded at length and harvested at length (unweighted for cod and weighted for haddock). 
 
 This code cleans the simulated catch at length data compiled in catch_at_length_calibration.do and saved in baseline_catch_at_length_observed.csv and formats the data for use in the rec dashboard. 
 
@@ -19,7 +19,134 @@ This code cleans the simulated catch at length data compiled in catch_at_length_
 */
 
 
+
+// changed everything to 0 in execution control in model wrapper other than assemblemriplists and generate_baseline
+
+//raw observed numbers of fish
+u "$misc_data_cd\rdb_raw_cat_len.dta", clear //  raw discards and harvest numbers at length for dashboard
+
+rename l_cm_bin length
+rename nfish_ab1 harvest 
+rename nfish_b2 discards
+
+replace season="summer" if season=="sum"
+replace season="winter" if season=="win"
+
+replace harvest = 0 if missing(harvest)
+replace discards = 0 if missing(discards)
+
+sort species season length
+
+twoway line harvest discards length if species=="cod" & season=="summer"
+twoway line harvest discards length if species=="cod" & season=="winter"
+
+twoway line harvest discards length if species=="hadd" & season=="summer"
+twoway line harvest discards length if species=="hadd" & season=="winter"
+
+//cant have discards and harvest numbers on same plot bc harvest is so high for some lengths
+
+
+
+//numbers of fish. this one is multiplied by total harvest and total discards
+u "$misc_data_cd\rdb_cat_len.dta", clear // file for processing catch at at length for dashboard
+
+gen tot_cat=ab1+b2
+rename l_cm_bin length
+rename n_ab1 harvest 
+rename n_b2 discards
+
+collapse (median) harvest discards tot_cat, by(season species length)
+tostring length, gen(length1)
+gen metric = length1+" "+"cm"
+gen units="number of fish"
+
+//opposite here, discards way higher than harvest
+twoway line harvest discards length if species=="cod" & season=="summer"
+twoway line harvest discards length if species=="cod" & season=="winter"
+
+//looks good for haddock
+twoway line harvest discards length if species=="hadd" & season=="summer"
+twoway line harvest discards length if species=="hadd" & season=="winter"
+
+
+
+
+
+//median observed probabilities
+u "$misc_data_cd\rdb_cat_len.dta", clear // file for processing catch at at length for dashboard
+
+// grab median proportions
+
+gen tot_cat=ab1+b2
+gen prop_cal=n_fish/tot_cat
+
+rename l_cm_bin length
+
+collapse (median) prop_cal prop_ab1 prop_b2, by(season species length)
+tostring length, gen(length1)
+gen metric = length1+" "+"cm"
+gen units="proportion of catch (observed)" 
+
+egen sum=sum(prop_cal), by(species season ) 
+
+twoway line prop_cal length if species=="cod" & season=="summer"
+
+twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="summer"
+twoway line prop_ab1 prop_b2 prop_cal length if species=="cod" & season=="winter"
+twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="summer"
+twoway line prop_ab1 prop_b2 prop_cal length if species=="hadd" & season=="winter"
+
+
+rename prop_ab1 harvest
+rename prop_b2 discards
+
+//it's bad for cod summer bc over 80% of harvest is one length
+twoway line harvest discards length if species=="cod" & season=="summer"
+twoway line harvest discards length if species=="cod" & season=="winter"
+
+twoway line harvest discards length if species=="hadd" & season=="summer"
+twoway line harvest discards length if species=="hadd" & season=="winter"
+
+
+
+// this is the same numbers as above but trims the ends of the length distribution with 0's
 import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
+collapse (median) observed_prob, by(season species length)
+tostring length, gen(length1)
+gen metric = length1+" "+"cm"
+gen units="proportion of catch (observed)" 
+
+egen sum=sum(observed_prob), by(species season ) 
+
+twoway line observed_prob length if species=="cod" & season=="summer"
+
+
+
+
+//getting the fitted prob
+import delimited "$misc_data_cd\baseline_catch_at_length.csv", clear
+
+collapse (median) observed_prob fitted_prob, by(season species length)
+tostring length, gen(length1)
+gen metric = length1+" "+"cm"
+gen units="proportion of catch (observed)" 
+
+egen sum=sum(observed_prob), by(species season ) 
+egen sum1=sum(fitted_prob), by(species season ) 
+
+twoway line observed_prob length if species=="cod" & season=="summer"
+
+twoway line fitted_prob length if species=="cod" & season=="summer"
+twoway line fitted_prob length if species=="hadd" & season=="summer"
+
+
+
+
+
+
+
+//stuff from thurs
+//import delimited "$misc_data_cd\baseline_catch_at_length_observed.csv", clear
 
 
 collapse (median) n_fish, by(length season species)

--- a/Code/pre_sim/rdb_processing_catch_per_trip.do
+++ b/Code/pre_sim/rdb_processing_catch_per_trip.do
@@ -123,12 +123,10 @@ replace year=2024 if month>=11
 gen stock_abbrev="WGOM"
 gen fishery= "NE Groundfish"
 
-//ask lou when he pulled the dta's here. this folder said he'd saved them May 12 when I copied them locally: https://drive.google.com/drive/folders/1wIlpn5Q8_iBnZ0NUlKVVpzyI7x97zAdi   
-//Did he pull in updated MRIP data that day? 
+//Update this 
 gen data_version="2026-05-12"
 //state will be NA
 gen state=.
-//what should source be? recDST? simulated? recDST/MRIP? RDM? - ask Min-Yang
 gen source="model intermediate"
 
 *reorder columns. sort data on month, common, mode.


### PR DESCRIPTION
This processes catch at length for the dashboard and pushes an Rds to google drive. It's the observed and fitted probabilities like we talked about with the cm converted to inches. I already tested everything and it worked but if you want to: 


/*
loc pull_assessment = 0		 		// Pull Assessment data
loc processMRIP = 0		 			// deal with casing MRIP data
loc assemblemriplists = 0		 	// deal with casing MRIP data

loc estimate_dtrips = 0				// Estimate Directed Trips 
loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
loc catch_per_trip1 = 0				// Part 1 of catch per trip
loc copula_in_R = 0					// Copula model in R
loc catch_per_trip2 = 0				// Part 2 of catch per trip
loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
loc prep_cpt_for_dashboard= 0		// prep data for dashboard
loc Rpush_cpt_to_gdrive =0 			// Push to google drive in R
loc angler_demogs	=0				// add additonal angler demographics
loc generate_baseline=0				// Generate baseline-year catch-at-length
loc prep_cal_for_dashboard= 1		// Prep catch at length data for dashboard
loc Rpush_cal_to_gdrive =1 			// Push to google drive in R
loc catch_at_length_project=0			// Generate projection-year catch-at-length
loc run_calibration=0						// Run calibration routine in R
*/


If you havent run the catch_at_length_calibration.do with 101 draws you will need to download baseline_catch_at_length.csv from the google miscellaneous folder locally and then you can run the above in the execution control.

I'll do the documentation next. 