### PR TITLE
Patch mrip oracle

### DIFF
--- a/Code/pre_sim/directed_trips_calibration.do
+++ b/Code/pre_sim/directed_trips_calibration.do
@@ -67,8 +67,6 @@ set seed $seed
 di "directed_trips_calibration: estimating directed trips from MRIP; this may take a while ..."
 
 clear
-global 
-
 tempfile tl1 cl1
 dsconcat $triplist
 
@@ -607,8 +605,6 @@ export delimited using "$misc_data_cd\next_year_calendar_adjustments.csv",  repl
 di "directed_trips_calibration: estimating MRIP directed-trip totals by mode ..."
 
 clear
-global 
-
 tempfile tl1 cl1
 dsconcat $triplist
 
@@ -796,7 +792,7 @@ save "$misc_data_cd\mrip_dtrip_by_mode.dta", replace
 di "directed_trips_calibration: estimating MRIP directed-trip totals by mode and month ..."
 
 clear
-global 
+ 
 
 tempfile tl1 cl1
 dsconcat $triplist
@@ -985,7 +981,7 @@ save "$misc_data_cd\mrip_dtrip_by_mode_month.dta", replace
 di "directed_trips_calibration: estimating MRIP directed-trip totals by mode and season ..."
 
 clear
-global 
+ 
 
 tempfile tl1 cl1
 dsconcat $triplist

--- a/Code/pre_sim/get_mrip_oracle.R
+++ b/Code/pre_sim/get_mrip_oracle.R
@@ -75,29 +75,10 @@ mrip_pull <- mrip_microdata(
 dbDisconnect(con_name)
 
 
-# A little data munging
-
-# all lower case
-mrip_pull <- map(mrip_pull, ~rename_with(.x, tolower)
-                 )
-
 # append a mrip_pull_date column (today's date) to every element, formatted as
 # "Month DD, YYYY" (the %B %d, %Y example renders e.g. as "July 16, 2026")
 mrip_pull <- map(mrip_pull, ~ mutate(
-  .x, mrip_pull_date =as.character(format(todaysdate,"%B %d, %Y") ) )
-  )
-
-#force certain things to character
-mrip_pull <- map(mrip_pull, ~ mutate(
-  .x, across(c(strat_id, psu_id, id_code,zip), as.character))
-  )
-
-
-# write all the elements of x to a dta file
-walk2(mrip_pull, names(mrip_pull), ~ write_dta(
-  .x,
-  path=file.path(output_folder, glue("mrip_{.y}.dta"))
-  )
+  .x, MRIP_PULL_DATE =as.character(format(todaysdate,"%B %d, %Y") ) )
 )
 
 # append the mrip_pull_date to the mrip_pull list as a tibble
@@ -113,4 +94,29 @@ message("First Year in Data: ",first_yr)
 message("Last Year in Data: ",last_yr)
 
 message("MRIP data successfully pulled on: ", format(todaysdate,"%B %d, %Y") )
+
+
+
+# A little data munging
+# Downstream stata code needs to be in all caps and we need to ensure the date formats are done properly
+# all lower case
+
+mrip_pull$mrip_pull_date<-NULL
+
+mrip_pull <- map(mrip_pull, ~rename_with(.x, tolower)
+                 )
+
+#force certain things to character
+mrip_pull <- map(mrip_pull, ~ mutate(
+  .x, across(c(strat_id, psu_id, id_code,zip), as.character))
+  )
+
+
+# write all the elements of x to a dta file
+walk2(mrip_pull, names(mrip_pull), ~ write_dta(
+  .x,
+  path=file.path(output_folder, glue("mrip_{.y}.dta"))
+  )
+)
+
 


### PR DESCRIPTION
I tested with this setup for the model_wrapper.do


```
// Control which modules to run (set to 0 to skip)
loc pull_assessment = 0		 		// Pull Assessment data
loc pull_MRIP = 1		 			// Pull MRIP data.

loc processMRIP = 0	 			// deal with casing MRIP data
loc assemblemriplists =0		 	// deal with casing MRIP data
loc estimate_dtrips = 1				// Estimate Directed Trips
loc costs_per_trip = 0  			// Create Distributions of costs per trip (run 1x)
loc draw_angler_preferences = 0		// Create draw of angler preference parameters (run 1x)
loc catch_per_trip1 = 1			// Part 1 of catch per trip
loc copula_in_R = 0					// Copula model in R
loc catch_per_trip2 = 0				// Part 2 of catch per trip
loc compare_calibration_MRIP = 0	// compare calibration output to MRIP
loc prep_cpt_for_dashboard= 0		// prep data for dashboard
loc Rpush_cpt_to_gdrive =0 			// Push to google drive in R
loc angler_demogs	=0				// add additional angler demographics
loc generate_baseline=0				// Generate baseline-year catch-at-length
loc prep_catch_at_length_for_dash= 0		// Prep catch at length data for dashboard
loc Rpush_catch_at_length_to_gdrive =0 			// Push catch at length data to  google drive in R
loc catch_at_length_project=0			// Generate projection-year catch-at-length
loc run_calibration=0						// Run calibration routine in R



// Prototyping: set proto=1 to override $ndraws down to 3 for a fast test run.
local proto = 0

if `proto' {
	global ndraws 3
}
```
